### PR TITLE
feat(report): add dashboard PDF export

### DIFF
--- a/app/Http/Controllers/Admin/DashboardReportController.php
+++ b/app/Http/Controllers/Admin/DashboardReportController.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Barryvdh\DomPDF\Facade\Pdf;
+use App\Models\Transaction;
+use App\Models\Product;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+
+class DashboardReportController extends Controller
+{
+    public function daily(Request $request)
+    {
+        $date = $request->get('date', Carbon::today()->toDateString());
+        $parsedDate = Carbon::parse($date);
+
+        $transactions = Transaction::whereDate('created_at', $parsedDate)
+            ->where('payment_status', 'success')
+            ->get();
+
+        $totalOmzet      = $transactions->sum('total');
+        $jumlahTransaksi = $transactions->count();
+        $rataRata        = $jumlahTransaksi > 0 ? $totalOmzet / $jumlahTransaksi : 0;
+
+        // Ambil detail menu dari transaction_details
+        $menuSales = DB::table('transaction_details')
+            ->join('products', 'transaction_details.product_id', '=', 'products.id')
+            ->join('transactions', 'transaction_details.transaction_id', '=', 'transactions.id')
+            ->whereDate('transactions.created_at', $parsedDate)
+            ->where('transactions.payment_status', 'success')
+            ->select('products.name', DB::raw('SUM(transaction_details.quantity) as total_qty'))
+            ->groupBy('products.name')
+            ->orderByDesc('total_qty')
+            ->get();
+
+        $totalPorsi  = $menuSales->sum('total_qty');
+        $stokMenipis = Product::where('stock', '<=', 10)->get();
+
+        $data = [
+            'jenis'           => 'Harian',
+            'periode'         => $parsedDate->translatedFormat('d F Y'),
+            'totalOmzet'      => $totalOmzet,
+            'jumlahTransaksi' => $jumlahTransaksi,
+            'rataRata'        => $rataRata,
+            'totalPorsi'      => $totalPorsi,
+            'menuSales'       => $menuSales,
+            'stokMenipis'     => $stokMenipis,
+            'tanggalCetak'    => Carbon::now()->translatedFormat('d F Y, H:i'),
+        ];
+
+        $pdf = Pdf::loadView('pdf.dashboard-report', $data)
+                  ->setPaper('a4', 'portrait');
+
+        return $pdf->download('laporan-harian-' . $date . '.pdf');
+    }
+
+    public function monthly(Request $request)
+    {
+        $month = $request->get('month', Carbon::today()->month);
+        $year  = $request->get('year', Carbon::today()->year);
+
+        $transactions = Transaction::whereMonth('created_at', $month)
+            ->whereYear('created_at', $year)
+            ->where('payment_status', 'success')
+            ->get();
+
+        $totalOmzet      = $transactions->sum('total');
+        $jumlahTransaksi = $transactions->count();
+        $rataRata        = $jumlahTransaksi > 0 ? $totalOmzet / $jumlahTransaksi : 0;
+
+        $menuSales = DB::table('transaction_details')
+            ->join('products', 'transaction_details.product_id', '=', 'products.id')
+            ->join('transactions', 'transaction_details.transaction_id', '=', 'transactions.id')
+            ->whereMonth('transactions.created_at', $month)
+            ->whereYear('transactions.created_at', $year)
+            ->where('transactions.payment_status', 'success')
+            ->select('products.name', DB::raw('SUM(transaction_details.quantity) as total_qty'))
+            ->groupBy('products.name')
+            ->orderByDesc('total_qty')
+            ->get();
+
+        $totalPorsi  = $menuSales->sum('total_qty');
+        $stokMenipis = Product::where('stock', '<=', 10)->get();
+        $namaBulan   = Carbon::createFromDate($year, $month, 1)->translatedFormat('F Y');
+
+        $data = [
+            'jenis'           => 'Bulanan',
+            'periode'         => $namaBulan,
+            'totalOmzet'      => $totalOmzet,
+            'jumlahTransaksi' => $jumlahTransaksi,
+            'rataRata'        => $rataRata,
+            'totalPorsi'      => $totalPorsi,
+            'menuSales'       => $menuSales,
+            'stokMenipis'     => $stokMenipis,
+            'tanggalCetak'    => Carbon::now()->translatedFormat('d F Y, H:i'),
+        ];
+
+        $pdf = Pdf::loadView('pdf.dashboard-report', $data)
+                  ->setPaper('a4', 'portrait');
+
+        return $pdf->download('laporan-bulanan-' . $year . '-' . $month . '.pdf');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "barryvdh/laravel-dompdf": "^3.1",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
         "livewire/livewire": "^3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,85 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4da2d8e02fcacd1f780ae8445e785010",
+    "content-hash": "dbcfa3aa3b4b5217d2e12952afabac4b",
     "packages": [
+        {
+            "name": "barryvdh/laravel-dompdf",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-dompdf.git",
+                "reference": "ee3b72b19ccdf57d0243116ecb2b90261344dedc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-dompdf/zipball/ee3b72b19ccdf57d0243116ecb2b90261344dedc",
+                "reference": "ee3b72b19ccdf57d0243116ecb2b90261344dedc",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/dompdf": "^3.0",
+                "illuminate/support": "^9|^10|^11|^12|^13.0",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "larastan/larastan": "^2.7|^3.0",
+                "orchestra/testbench": "^7|^8|^9.16|^10|^11.0",
+                "phpro/grumphp": "^2.5",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "PDF": "Barryvdh\\DomPDF\\Facade\\Pdf",
+                        "Pdf": "Barryvdh\\DomPDF\\Facade\\Pdf"
+                    },
+                    "providers": [
+                        "Barryvdh\\DomPDF\\ServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\DomPDF\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "A DOMPDF Wrapper for Laravel",
+            "keywords": [
+                "dompdf",
+                "laravel",
+                "pdf"
+            ],
+            "support": {
+                "issues": "https://github.com/barryvdh/laravel-dompdf/issues",
+                "source": "https://github.com/barryvdh/laravel-dompdf/tree/v3.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-21T08:51:10+00:00"
+        },
         {
             "name": "brick/math",
             "version": "0.14.8",
@@ -376,6 +453,161 @@
                 }
             ],
             "time": "2024-02-05T11:56:58+00:00"
+        },
+        {
+            "name": "dompdf/dompdf",
+            "version": "v3.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/dompdf.git",
+                "reference": "f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496",
+                "reference": "f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/php-font-lib": "^1.0.0",
+                "dompdf/php-svg-lib": "^1.0.0",
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "masterminds/html5": "^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "mockery/mockery": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.4 || ^5.4 || ^6.2 || ^7.0"
+            },
+            "suggest": {
+                "ext-gd": "Needed to process images",
+                "ext-gmagick": "Improves image processing performance",
+                "ext-imagick": "Improves image processing performance",
+                "ext-zlib": "Needed for pdf stream compression"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dompdf\\": "src/"
+                },
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "The Dompdf Community",
+                    "homepage": "https://github.com/dompdf/dompdf/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
+            "homepage": "https://github.com/dompdf/dompdf",
+            "support": {
+                "issues": "https://github.com/dompdf/dompdf/issues",
+                "source": "https://github.com/dompdf/dompdf/tree/v3.1.5"
+            },
+            "time": "2026-03-03T13:54:37+00:00"
+        },
+        {
+            "name": "dompdf/php-font-lib",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-font-lib.git",
+                "reference": "a6e9a688a2a80016ac080b97be73d3e10c444c9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/a6e9a688a2a80016ac080b97be73d3e10c444c9a",
+                "reference": "a6e9a688a2a80016ac080b97be73d3e10c444c9a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11 || ^12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The FontLib Community",
+                    "homepage": "https://github.com/dompdf/php-font-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/dompdf/php-font-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-font-lib/issues",
+                "source": "https://github.com/dompdf/php-font-lib/tree/1.0.2"
+            },
+            "time": "2026-01-20T14:10:26+00:00"
+        },
+        {
+            "name": "dompdf/php-svg-lib",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-svg-lib.git",
+                "reference": "8259ffb930817e72b1ff1caef5d226501f3dfeb1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/8259ffb930817e72b1ff1caef5d226501f3dfeb1",
+                "reference": "8259ffb930817e72b1ff1caef5d226501f3dfeb1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabberworm/php-css-parser": "^8.4 || ^9.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Svg\\": "src/Svg"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The SvgLib Community",
+                    "homepage": "https://github.com/dompdf/php-svg-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse and export to PDF SVG files.",
+            "homepage": "https://github.com/dompdf/php-svg-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-svg-lib/issues",
+                "source": "https://github.com/dompdf/php-svg-lib/tree/1.0.2"
+            },
+            "time": "2026-01-02T16:01:13+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
@@ -2096,6 +2328,73 @@
             "time": "2026-02-26T00:58:19+00:00"
         },
         {
+            "name": "masterminds/html5",
+            "version": "2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fcf91eb64359852f00d921887b219479b4f21251",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.0"
+            },
+            "time": "2025-07-25T09:04:22+00:00"
+        },
+        {
             "name": "mike42/escpos-php",
             "version": "v2.2",
             "source": {
@@ -3428,6 +3727,86 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.2"
             },
             "time": "2025-12-14T04:43:48+00:00"
+        },
+        {
+            "name": "sabberworm/php-css-parser",
+            "version": "v9.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MyIntervals/PHP-CSS-Parser.git",
+                "reference": "88dbd0f7f91abbfe4402d0a3071e9ff4d81ed949"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/88dbd0f7f91abbfe4402d0a3071e9ff4d81ed949",
+                "reference": "88dbd0f7f91abbfe4402d0a3071e9ff4d81ed949",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": "^7.2.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "thecodingmachine/safe": "^1.3 || ^2.5 || ^3.4"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "1.4.0",
+                "phpstan/extension-installer": "1.4.3",
+                "phpstan/phpstan": "1.12.32 || 2.1.32",
+                "phpstan/phpstan-phpunit": "1.4.2 || 2.0.8",
+                "phpstan/phpstan-strict-rules": "1.6.2 || 2.0.7",
+                "phpunit/phpunit": "8.5.52",
+                "rawr/phpunit-data-provider": "3.3.1",
+                "rector/rector": "1.2.10 || 2.2.8",
+                "rector/type-perfect": "1.0.0 || 2.1.0",
+                "squizlabs/php_codesniffer": "4.0.1",
+                "thecodingmachine/phpstan-safe-rule": "1.2.0 || 1.4.1"
+            },
+            "suggest": {
+                "ext-mbstring": "for parsing UTF-8 CSS"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Rule/Rule.php",
+                    "src/RuleSet/RuleContainer.php"
+                ],
+                "psr-4": {
+                    "Sabberworm\\CSS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                },
+                {
+                    "name": "Oliver Klee",
+                    "email": "github@oliverklee.de"
+                },
+                {
+                    "name": "Jake Hotson",
+                    "email": "jake.github@qzdesign.co.uk"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "https://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "support": {
+                "issues": "https://github.com/MyIntervals/PHP-CSS-Parser/issues",
+                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v9.3.0"
+            },
+            "time": "2026-03-03T17:31:43+00:00"
         },
         {
             "name": "symfony/clock",
@@ -5920,6 +6299,149 @@
                 }
             ],
             "time": "2026-02-15T10:53:20+00:00"
+        },
+        {
+            "name": "thecodingmachine/safe",
+            "version": "v3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecodingmachine/safe.git",
+                "reference": "705683a25bacf0d4860c7dea4d7947bfd09eea19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/705683a25bacf0d4860c7dea4d7947bfd09eea19",
+                "reference": "705683a25bacf0d4860c7dea4d7947bfd09eea19",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpstan/phpstan": "^2",
+                "phpunit/phpunit": "^10",
+                "squizlabs/php_codesniffer": "^3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/special_cases.php",
+                    "generated/apache.php",
+                    "generated/apcu.php",
+                    "generated/array.php",
+                    "generated/bzip2.php",
+                    "generated/calendar.php",
+                    "generated/classobj.php",
+                    "generated/com.php",
+                    "generated/cubrid.php",
+                    "generated/curl.php",
+                    "generated/datetime.php",
+                    "generated/dir.php",
+                    "generated/eio.php",
+                    "generated/errorfunc.php",
+                    "generated/exec.php",
+                    "generated/fileinfo.php",
+                    "generated/filesystem.php",
+                    "generated/filter.php",
+                    "generated/fpm.php",
+                    "generated/ftp.php",
+                    "generated/funchand.php",
+                    "generated/gettext.php",
+                    "generated/gmp.php",
+                    "generated/gnupg.php",
+                    "generated/hash.php",
+                    "generated/ibase.php",
+                    "generated/ibmDb2.php",
+                    "generated/iconv.php",
+                    "generated/image.php",
+                    "generated/imap.php",
+                    "generated/info.php",
+                    "generated/inotify.php",
+                    "generated/json.php",
+                    "generated/ldap.php",
+                    "generated/libxml.php",
+                    "generated/lzf.php",
+                    "generated/mailparse.php",
+                    "generated/mbstring.php",
+                    "generated/misc.php",
+                    "generated/mysql.php",
+                    "generated/mysqli.php",
+                    "generated/network.php",
+                    "generated/oci8.php",
+                    "generated/opcache.php",
+                    "generated/openssl.php",
+                    "generated/outcontrol.php",
+                    "generated/pcntl.php",
+                    "generated/pcre.php",
+                    "generated/pgsql.php",
+                    "generated/posix.php",
+                    "generated/ps.php",
+                    "generated/pspell.php",
+                    "generated/readline.php",
+                    "generated/rnp.php",
+                    "generated/rpminfo.php",
+                    "generated/rrd.php",
+                    "generated/sem.php",
+                    "generated/session.php",
+                    "generated/shmop.php",
+                    "generated/sockets.php",
+                    "generated/sodium.php",
+                    "generated/solr.php",
+                    "generated/spl.php",
+                    "generated/sqlsrv.php",
+                    "generated/ssdeep.php",
+                    "generated/ssh2.php",
+                    "generated/stream.php",
+                    "generated/strings.php",
+                    "generated/swoole.php",
+                    "generated/uodbc.php",
+                    "generated/uopz.php",
+                    "generated/url.php",
+                    "generated/var.php",
+                    "generated/xdiff.php",
+                    "generated/xml.php",
+                    "generated/xmlrpc.php",
+                    "generated/yaml.php",
+                    "generated/yaz.php",
+                    "generated/zip.php",
+                    "generated/zlib.php"
+                ],
+                "classmap": [
+                    "lib/DateTime.php",
+                    "lib/DateTimeImmutable.php",
+                    "lib/Exceptions/",
+                    "generated/Exceptions/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
+            "support": {
+                "issues": "https://github.com/thecodingmachine/safe/issues",
+                "source": "https://github.com/thecodingmachine/safe/tree/v3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/OskarStark",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/shish",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/silasjoisten",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-04T18:08:13+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -9492,5 +10014,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/resources/views/livewire/admin/dashboard.blade.php
+++ b/resources/views/livewire/admin/dashboard.blade.php
@@ -11,86 +11,74 @@
                         Rekapitulasi omzet harian, omzet bulanan, stok, dan laporan menu terlaris.
                     </p>
                 </div>
-                {{-- Tombol Export PDF --}}
-                <div class="flex flex-wrap gap-3 mb-6">
-                    {{-- Export Harian --}}
-                    <form method="GET" action="{{ route('admin.dashboard.pdf.daily') }}" target="_blank" class="flex items-center gap-2">
-                        <input type="date" name="date" value="{{ date('Y-m-d') }}"
-                            class="border border-amber-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500">
-                        <button type="submit"
-                                class="flex items-center gap-2 bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition">
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
-                            </svg>
-                            Export PDF Harian
+                <div class="flex flex-col gap-3">
+                    <form wire:submit.prevent="applyReportFilter" class="flex flex-col gap-3 lg:flex-row lg:items-end">
+                        <div>
+                            <label class="block text-xs font-medium text-slate-600 mb-1">
+                                Tanggal Laporan Harian
+                            </label>
+
+                            <input type="date" wire:model="dailyDateInput"
+                                class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-slate-900 focus:ring-2 focus:ring-slate-900">
+
+                            @error('dailyDateInput')
+                                <p class="mt-1 text-xs text-red-600">{{ $message }}</p>
+                            @enderror
+                        </div>
+
+                        <div>
+                            <label class="block text-xs font-medium text-slate-600 mb-1">
+                                Bulan Laporan
+                            </label>
+
+                            <input type="month" wire:model="monthInput"
+                                class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-slate-900 focus:ring-2 focus:ring-slate-900">
+
+                            @error('monthInput')
+                                <p class="mt-1 text-xs text-red-600">{{ $message }}</p>
+                            @enderror
+                        </div>
+
+                        <button type="submit" wire:loading.attr="disabled" wire:target="applyReportFilter"
+                            class="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-800 disabled:opacity-60">
+                            <span wire:loading.remove wire:target="applyReportFilter">Terapkan</span>
+                            <span wire:loading wire:target="applyReportFilter">Memuat...</span>
+                        </button>
+
+                        <button type="button" wire:click="resetReportFilter" wire:loading.attr="disabled"
+                            wire:target="resetReportFilter"
+                            class="rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50 disabled:opacity-60">
+                            Reset
                         </button>
                     </form>
 
-                    {{-- Export Bulanan --}}
-                    <form method="GET" action="{{ route('admin.dashboard.pdf.monthly') }}" target="_blank" class="flex items-center gap-2">
-                        <select name="month" class="border border-amber-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500">
-                            @for($m = 1; $m <= 12; $m++)
-                                <option value="{{ $m }}" {{ $m == date('n') ? 'selected' : '' }}>
-                                    {{ \Carbon\Carbon::create()->month($m)->translatedFormat('F') }}
-                                </option>
-                            @endfor
-                        </select>
-                        <select name="year" class="border border-amber-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500">
-                            @for($y = date('Y'); $y >= date('Y') - 2; $y--)
-                                <option value="{{ $y }}">{{ $y }}</option>
-                            @endfor
-                        </select>
-                        <button type="submit"
-                                class="flex items-center gap-2 bg-amber-800 hover:bg-amber-900 text-white px-4 py-2 rounded-lg text-sm font-medium transition">
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
-                            </svg>
-                            Export PDF Bulanan
-                        </button>
-                    </form>
+                    <div class="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                        <form method="GET" action="{{ route('admin.dashboard.pdf.daily') }}" target="_blank">
+                            <input type="hidden" name="date" value="{{ $selectedDailyDate }}">
+                            <button type="submit"
+                                class="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-800 sm:w-auto">
+                                <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                        d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                                </svg>
+                                Export PDF Harian
+                            </button>
+                        </form>
+
+                        <form method="GET" action="{{ route('admin.dashboard.pdf.monthly') }}" target="_blank">
+                            <input type="hidden" name="month" value="{{ (int) substr($selectedMonthPeriod, 5, 2) }}">
+                            <input type="hidden" name="year" value="{{ substr($selectedMonthPeriod, 0, 4) }}">
+                            <button type="submit"
+                                class="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-800 sm:w-auto">
+                                <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                        d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                                </svg>
+                                Export PDF Bulanan
+                            </button>
+                        </form>
+                    </div>
                 </div>
-
-                <form wire:submit.prevent="applyReportFilter" class="flex flex-col gap-3 lg:flex-row lg:items-end">
-                    <div>
-                        <label class="block text-xs font-medium text-slate-600 mb-1">
-                            Tanggal Laporan Harian
-                        </label>
-
-                        <input type="date" wire:model="dailyDateInput"
-                            class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-slate-900 focus:ring-2 focus:ring-slate-900">
-
-                        @error('dailyDateInput')
-                            <p class="mt-1 text-xs text-red-600">{{ $message }}</p>
-                        @enderror
-                    </div>
-
-                    <div>
-                        <label class="block text-xs font-medium text-slate-600 mb-1">
-                            Bulan Laporan
-                        </label>
-
-                        <input type="month" wire:model="monthInput"
-                            class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-slate-900 focus:ring-2 focus:ring-slate-900">
-
-                        @error('monthInput')
-                            <p class="mt-1 text-xs text-red-600">{{ $message }}</p>
-                        @enderror
-                    </div>
-
-                    <button type="submit" wire:loading.attr="disabled" wire:target="applyReportFilter"
-                        class="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-800 disabled:opacity-60">
-                        <span wire:loading.remove wire:target="applyReportFilter">Terapkan</span>
-                        <span wire:loading wire:target="applyReportFilter">Memuat...</span>
-                    </button>
-
-                    <button type="button" wire:click="resetReportFilter" wire:loading.attr="disabled"
-                        wire:target="resetReportFilter"
-                        class="rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50 disabled:opacity-60">
-                        Reset
-                    </button>
-                </form>
             </div>
 
             @if ($lowStockProductsCount > 0)

--- a/resources/views/livewire/admin/dashboard.blade.php
+++ b/resources/views/livewire/admin/dashboard.blade.php
@@ -11,6 +11,46 @@
                         Rekapitulasi omzet harian, omzet bulanan, stok, dan laporan menu terlaris.
                     </p>
                 </div>
+                {{-- Tombol Export PDF --}}
+                <div class="flex flex-wrap gap-3 mb-6">
+                    {{-- Export Harian --}}
+                    <form method="GET" action="{{ route('admin.dashboard.pdf.daily') }}" target="_blank" class="flex items-center gap-2">
+                        <input type="date" name="date" value="{{ date('Y-m-d') }}"
+                            class="border border-amber-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500">
+                        <button type="submit"
+                                class="flex items-center gap-2 bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+                            </svg>
+                            Export PDF Harian
+                        </button>
+                    </form>
+
+                    {{-- Export Bulanan --}}
+                    <form method="GET" action="{{ route('admin.dashboard.pdf.monthly') }}" target="_blank" class="flex items-center gap-2">
+                        <select name="month" class="border border-amber-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500">
+                            @for($m = 1; $m <= 12; $m++)
+                                <option value="{{ $m }}" {{ $m == date('n') ? 'selected' : '' }}>
+                                    {{ \Carbon\Carbon::create()->month($m)->translatedFormat('F') }}
+                                </option>
+                            @endfor
+                        </select>
+                        <select name="year" class="border border-amber-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500">
+                            @for($y = date('Y'); $y >= date('Y') - 2; $y--)
+                                <option value="{{ $y }}">{{ $y }}</option>
+                            @endfor
+                        </select>
+                        <button type="submit"
+                                class="flex items-center gap-2 bg-amber-800 hover:bg-amber-900 text-white px-4 py-2 rounded-lg text-sm font-medium transition">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+                            </svg>
+                            Export PDF Bulanan
+                        </button>
+                    </form>
+                </div>
 
                 <form wire:submit.prevent="applyReportFilter" class="flex flex-col gap-3 lg:flex-row lg:items-end">
                     <div>

--- a/resources/views/pdf/dashboard-report.blade.php
+++ b/resources/views/pdf/dashboard-report.blade.php
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+    <meta charset="UTF-8">
+    <title>Laporan {{ $jenis }} - Nasi Lawar Ulucatu</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body { font-family: 'DejaVu Sans', sans-serif; font-size: 12px; color: #1a1a1a; }
+
+        .header {
+            background-color: #b45309;
+            color: white;
+            padding: 20px 24px;
+            margin-bottom: 20px;
+        }
+        .header h1 { font-size: 20px; font-weight: bold; }
+        .header p  { font-size: 11px; margin-top: 4px; opacity: 0.9; }
+
+        .section { margin: 0 24px 18px 24px; }
+        .section-title {
+            font-size: 13px;
+            font-weight: bold;
+            color: #92400e;
+            border-bottom: 2px solid #f59e0b;
+            padding-bottom: 4px;
+            margin-bottom: 10px;
+        }
+
+        /* Ringkasan cards */
+        .summary-grid {
+            display: table;
+            width: 100%;
+            border-spacing: 8px;
+        }
+        .summary-row { display: table-row; }
+        .summary-card {
+            display: table-cell;
+            width: 25%;
+            background: #fffbeb;
+            border: 1px solid #fde68a;
+            border-radius: 6px;
+            padding: 10px 12px;
+            text-align: center;
+        }
+        .summary-card .label { font-size: 10px; color: #78716c; margin-bottom: 4px; }
+        .summary-card .value { font-size: 14px; font-weight: bold; color: #92400e; }
+
+        /* Tabel */
+        table { width: 100%; border-collapse: collapse; }
+        th {
+            background-color: #92400e;
+            color: white;
+            padding: 7px 10px;
+            text-align: left;
+            font-size: 11px;
+        }
+        td { padding: 6px 10px; font-size: 11px; border-bottom: 1px solid #e5e7eb; }
+        tr:nth-child(even) td { background-color: #fffbeb; }
+
+        /* Stok menipis */
+        .stok-warning { color: #dc2626; font-weight: bold; }
+
+        .footer {
+            margin: 20px 24px 0 24px;
+            padding-top: 10px;
+            border-top: 1px solid #d1d5db;
+            font-size: 10px;
+            color: #9ca3af;
+            text-align: right;
+        }
+    </style>
+</head>
+<body>
+
+{{-- HEADER --}}
+<div class="header">
+    <h1>Laporan {{ $jenis }} — Nasi Lawar Ulucatu</h1>
+    <p>Periode: {{ $periode }}</p>
+</div>
+
+{{-- RINGKASAN --}}
+<div class="section">
+    <div class="section-title">Ringkasan Omzet & Transaksi</div>
+    <table class="summary-grid">
+        <tr class="summary-row">
+            <td class="summary-card">
+                <div class="label">Total Omzet</div>
+                <div class="value">Rp {{ number_format($totalOmzet, 0, ',', '.') }}</div>
+            </td>
+            <td class="summary-card">
+                <div class="label">Jumlah Transaksi</div>
+                <div class="value">{{ $jumlahTransaksi }}</div>
+            </td>
+            <td class="summary-card">
+                <div class="label">Rata-rata Transaksi</div>
+                <div class="value">Rp {{ number_format($rataRata, 0, ',', '.') }}</div>
+            </td>
+            <td class="summary-card">
+                <div class="label">Total Porsi Terjual</div>
+                <div class="value">{{ $totalPorsi }} porsi</div>
+            </td>
+        </tr>
+    </table>
+</div>
+
+{{-- MENU TERLARIS --}}
+<div class="section">
+    <div class="section-title">Menu Terlaris</div>
+    @if(count($menuSales) > 0)
+    <table>
+        <thead>
+            <tr>
+                <th>#</th>
+                <th>Nama Menu</th>
+                <th>Jumlah Terjual (Porsi)</th>
+            </tr>
+        </thead>
+        <tbody>
+    @foreach($menuSales as $menu)
+    <tr>
+        <td>{{ $loop->iteration }}</td>
+        <td>{{ $menu->name }}</td>
+        <td>{{ $menu->total_qty }} porsi</td>
+    </tr>
+    @endforeach
+    </table>
+    @else
+        <p style="color:#9ca3af; font-style:italic;">Tidak ada data menu pada periode ini.</p>
+    @endif
+</div>
+
+{{-- STOK MENIPIS --}}
+<div class="section">
+    <div class="section-title">Pantauan Stok / Sisa Porsi Menipis</div>
+    @if($stokMenipis->count() > 0)
+    <table>
+        <thead>
+            <tr>
+                <th>#</th>
+                <th>Nama Produk</th>
+                <th>Sisa Stok</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($stokMenipis as $produk)
+            <tr>
+                <td>{{ $loop->iteration }}</td>
+                <td>{{ $produk->name }}</td>
+                <td class="stok-warning">{{ $produk->stock }} porsi</td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+    @else
+        <p style="color:#16a34a;">✓ Semua stok dalam kondisi aman.</p>
+    @endif
+</div>
+
+{{-- FOOTER --}}
+<div class="footer">
+    Dicetak pada: {{ $tanggalCetak }} &nbsp;|&nbsp; Nasi Lawar Ulucatu — Sistem POS
+</div>
+
+</body>
+</html>

--- a/resources/views/pdf/dashboard-report.blade.php
+++ b/resources/views/pdf/dashboard-report.blade.php
@@ -5,28 +5,55 @@
     <title>Laporan {{ $jenis }} - Nasi Lawar Ulucatu</title>
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
-        body { font-family: 'DejaVu Sans', sans-serif; font-size: 12px; color: #1a1a1a; }
+        body {
+            background: #f8fafc;
+            color: #0f172a;
+            font-family: 'DejaVu Sans', sans-serif;
+            font-size: 12px;
+        }
+
+        .page {
+            background: #ffffff;
+            margin: 18px;
+            padding: 22px;
+        }
 
         .header {
-            background-color: #b45309;
-            color: white;
-            padding: 20px 24px;
-            margin-bottom: 20px;
+            background: #0f172a;
+            border-radius: 14px;
+            color: #ffffff;
+            padding: 22px 24px;
+            margin-bottom: 22px;
         }
-        .header h1 { font-size: 20px; font-weight: bold; }
-        .header p  { font-size: 11px; margin-top: 4px; opacity: 0.9; }
-
-        .section { margin: 0 24px 18px 24px; }
-        .section-title {
-            font-size: 13px;
+        .header h1 { font-size: 20px; font-weight: bold; letter-spacing: -0.2px; }
+        .header p  { color: #cbd5e1; font-size: 11px; margin-top: 5px; }
+        .header .badge {
+            background: #ecfdf5;
+            border-radius: 999px;
+            color: #047857;
+            display: inline-block;
+            font-size: 10px;
             font-weight: bold;
-            color: #92400e;
-            border-bottom: 2px solid #f59e0b;
-            padding-bottom: 4px;
             margin-bottom: 10px;
+            padding: 4px 10px;
+            text-transform: uppercase;
         }
 
-        /* Ringkasan cards */
+        .section { margin-bottom: 20px; }
+        .section-title {
+            border-bottom: 1px solid #e2e8f0;
+            color: #0f172a;
+            font-weight: bold;
+            font-size: 13px;
+            letter-spacing: -0.1px;
+            margin-bottom: 12px;
+            padding-bottom: 8px;
+        }
+        .section-title span {
+            border-left: 4px solid #10b981;
+            padding-left: 8px;
+        }
+
         .summary-grid {
             display: table;
             width: 100%;
@@ -34,53 +61,76 @@
         }
         .summary-row { display: table-row; }
         .summary-card {
-            display: table-cell;
-            width: 25%;
-            background: #fffbeb;
-            border: 1px solid #fde68a;
+            background: #ffffff;
+            border: 1px solid #e2e8f0;
             border-radius: 6px;
+            display: table-cell;
             padding: 10px 12px;
             text-align: center;
+            width: 25%;
         }
-        .summary-card .label { font-size: 10px; color: #78716c; margin-bottom: 4px; }
-        .summary-card .value { font-size: 14px; font-weight: bold; color: #92400e; }
+        .summary-card .label { color: #64748b; font-size: 10px; margin-bottom: 5px; }
+        .summary-card .value { color: #0f172a; font-size: 14px; font-weight: bold; }
 
-        /* Tabel */
         table { width: 100%; border-collapse: collapse; }
         th {
-            background-color: #92400e;
-            color: white;
-            padding: 7px 10px;
-            text-align: left;
+            background-color: #f1f5f9;
+            border-bottom: 1px solid #cbd5e1;
+            color: #334155;
             font-size: 11px;
+            padding: 8px 10px;
+            text-align: left;
         }
-        td { padding: 6px 10px; font-size: 11px; border-bottom: 1px solid #e5e7eb; }
-        tr:nth-child(even) td { background-color: #fffbeb; }
+        td { border-bottom: 1px solid #e2e8f0; font-size: 11px; padding: 8px 10px; }
+        tr:nth-child(even) td { background-color: #f8fafc; }
 
-        /* Stok menipis */
-        .stok-warning { color: #dc2626; font-weight: bold; }
+        .muted-message {
+            background: #f8fafc;
+            border: 1px solid #e2e8f0;
+            border-radius: 8px;
+            color: #64748b;
+            font-style: italic;
+            padding: 12px;
+        }
+        .safe-message {
+            background: #ecfdf5;
+            border: 1px solid #bbf7d0;
+            border-radius: 8px;
+            color: #047857;
+            padding: 12px;
+        }
+        .stock-pill {
+            background: #fef2f2;
+            border-radius: 999px;
+            color: #b91c1c;
+            display: inline-block;
+            font-weight: bold;
+            padding: 3px 8px;
+        }
 
         .footer {
-            margin: 20px 24px 0 24px;
-            padding-top: 10px;
-            border-top: 1px solid #d1d5db;
+            border-top: 1px solid #e2e8f0;
+            color: #94a3b8;
             font-size: 10px;
-            color: #9ca3af;
+            margin-top: 24px;
+            padding-top: 12px;
             text-align: right;
         }
     </style>
 </head>
 <body>
 
-{{-- HEADER --}}
-<div class="header">
-    <h1>Laporan {{ $jenis }} — Nasi Lawar Ulucatu</h1>
-    <p>Periode: {{ $periode }}</p>
-</div>
+<div class="page">
+    {{-- HEADER --}}
+    <div class="header">
+        <div class="badge">POS Report</div>
+        <h1>Laporan {{ $jenis }} - Nasi Lawar Ulucatu</h1>
+        <p>Periode {{ $periode }} • Ringkasan transaksi, menu terlaris, dan pantauan stok.</p>
+    </div>
 
-{{-- RINGKASAN --}}
-<div class="section">
-    <div class="section-title">Ringkasan Omzet & Transaksi</div>
+    {{-- RINGKASAN --}}
+    <div class="section">
+    <div class="section-title"><span>Ringkasan Omzet & Transaksi</span></div>
     <table class="summary-grid">
         <tr class="summary-row">
             <td class="summary-card">
@@ -101,11 +151,11 @@
             </td>
         </tr>
     </table>
-</div>
+    </div>
 
-{{-- MENU TERLARIS --}}
-<div class="section">
-    <div class="section-title">Menu Terlaris</div>
+    {{-- MENU TERLARIS --}}
+    <div class="section">
+    <div class="section-title"><span>Menu Terlaris</span></div>
     @if(count($menuSales) > 0)
     <table>
         <thead>
@@ -123,15 +173,16 @@
         <td>{{ $menu->total_qty }} porsi</td>
     </tr>
     @endforeach
+        </tbody>
     </table>
     @else
-        <p style="color:#9ca3af; font-style:italic;">Tidak ada data menu pada periode ini.</p>
+        <p class="muted-message">Tidak ada data menu pada periode ini.</p>
     @endif
-</div>
+    </div>
 
-{{-- STOK MENIPIS --}}
-<div class="section">
-    <div class="section-title">Pantauan Stok / Sisa Porsi Menipis</div>
+    {{-- STOK MENIPIS --}}
+    <div class="section">
+    <div class="section-title"><span>Pantauan Stok / Sisa Porsi Menipis</span></div>
     @if($stokMenipis->count() > 0)
     <table>
         <thead>
@@ -146,19 +197,20 @@
             <tr>
                 <td>{{ $loop->iteration }}</td>
                 <td>{{ $produk->name }}</td>
-                <td class="stok-warning">{{ $produk->stock }} porsi</td>
+                <td><span class="stock-pill">{{ $produk->stock }} porsi</span></td>
             </tr>
             @endforeach
         </tbody>
     </table>
     @else
-        <p style="color:#16a34a;">✓ Semua stok dalam kondisi aman.</p>
+        <p class="safe-message">Semua stok dalam kondisi aman.</p>
     @endif
-</div>
+    </div>
 
-{{-- FOOTER --}}
-<div class="footer">
-    Dicetak pada: {{ $tanggalCetak }} &nbsp;|&nbsp; Nasi Lawar Ulucatu — Sistem POS
+    {{-- FOOTER --}}
+    <div class="footer">
+        Dicetak pada: {{ $tanggalCetak }} &nbsp;|&nbsp; Nasi Lawar Ulucatu - Sistem POS
+    </div>
 </div>
 
 </body>

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,8 @@ Route::middleware(['auth', 'admin'])->group(function () {
     Route::get('/products', ProductIndex::class)->name('admin.product');
     Route::get('/category', CategoryIndex::class)->name('admin.category');
     Route::get('/transaction', TransactionIndex::class)->name('admin.transaction');
+    Route::get('/dashboard/report/pdf/daily', [App\Http\Controllers\Admin\DashboardReportController::class, 'daily'])->name('admin.dashboard.pdf.daily');
+    Route::get('/dashboard/report/pdf/monthly', [App\Http\Controllers\Admin\DashboardReportController::class, 'monthly'])->name('admin.dashboard.pdf.monthly');
 });
 
 // Route khusus Kasir (Admin juga boleh akses)


### PR DESCRIPTION
## Summary
- Add daily and monthly dashboard PDF export routes and controller
- Add export buttons below the dashboard report filters
- Refine PDF report layout with a minimalist POS-themed style

## Verification
- Ran composer install to install locked PDF dependencies
- Ran php artisan view:clear
- Rendered the PDF Blade template successfully via tinker